### PR TITLE
Update bit_list.info.yml

### DIFF
--- a/bit_list.info.yml
+++ b/bit_list.info.yml
@@ -1,4 +1,4 @@
-name: 'bit list'
+name: 'Bit List'
 type: 'module'
 description: 'bit list'
 package: 'bit list'


### PR DESCRIPTION
While evaluating this module I noticed that on the Extend page, the project name is in lower case and should be in title case to be consistent with the rest of the project names on the page.

"Capitalize the name of the module, because module names are proper nouns."

https://www.drupal.org/docs/develop/documenting-your-project/help-text-s...